### PR TITLE
restrict completion by scope name

### DIFF
--- a/lib/auto-close-html2.js
+++ b/lib/auto-close-html2.js
@@ -253,7 +253,7 @@ export default {
     },
     getTagName(str) {
         if (str.includes('<')) {
-            const matchResult = str.match(/^.*\<([a-zA-Z-_.#@]+)[^>]*?/)
+            const matchResult = str.match(/^.*\<([a-zA-Z0-9-_.#@]+)[^>]*?/)
             return matchResult && matchResult[1]
         }
     },

--- a/lib/auto-close-html2.js
+++ b/lib/auto-close-html2.js
@@ -54,6 +54,11 @@ export default {
             default: config.enabledFileTypes,
             description: 'Enable autoclose in these file types, default file type is `html`. (comma split)',
         },
+        enabledScopes: {
+            type: 'array',
+            default: config.enabledScopes,
+            description: 'Enable autoclose in only these scopes, default behavior is all. (comma split)',
+        },
         selfCloseTags: {
             type: 'array',
             default: config.selfCloseTags,
@@ -89,6 +94,7 @@ export default {
         this.subscriptions = new CompositeDisposable()
         this.observeConfig('auto-close-html2', [
             'enabledFileTypes',
+            'enabledScopes',
             'selfCloseTags',
             'addSlashToSelfCloseTag',
             'slashTriggerAutoClose',
@@ -136,6 +142,19 @@ export default {
             this.extension = parts[parts.length - 1]
         }
         return this.extension
+    },
+    _getScopeEnabled() {
+        if (config.enabledScopes.length === 0) {
+            return true
+        }
+
+        const cursorPositions = this.currentEditor.getCursorBufferPositions()
+        const filteredScopeArrays = cursorPositions
+            .map(point => this.currentEditor.scopeDescriptorForBufferPosition(point))
+            .map(descriptor => descriptor.getScopesArray())
+            .map(scopeArray => scopeArray.filter(scope => config.enabledScopes.includes(scope)))
+
+        return filteredScopeArrays.some(filteredScopes => filteredScopes.length > 0)
     },
     _paneItemChanged(paneItem) {
         if (!paneItem) {
@@ -192,6 +211,9 @@ export default {
     _closeTag(event) {
         const text = event.text
         const range = event.range
+        if (!this._getScopeEnabled()) {
+            return
+        }
         if (text === '\n') {
             this._addIndent(event.range)
             return

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,7 @@ export default {
     enabledFileTypes: [
         'html',
     ],
+    enabledScopes: [],
     selfCloseTags: [
         'br',
         'img',


### PR DESCRIPTION
Adds a new configuration option, `enabledScopes`, that allows the user to whitelist completion within a list of editor scopes. This furnishes a solution to the frustrating problem whereby TypeScript type parameters, which also use angle brackets, would be treated as HTML-like tags. See the screencast below for an example.

![2018-05-12 15 35 38](https://user-images.githubusercontent.com/2207980/39960961-6d1a2c8a-55fa-11e8-9e3a-7e1c85fc03cf.gif)
