### PR TITLE
Modified "getTagName" Regex to accept valid tag names that include numbers, such as h1, h2, h3, etc...

### DIFF
--- a/lib/auto-close-html2.js
+++ b/lib/auto-close-html2.js
@@ -231,8 +231,11 @@ export default {
     },
     getTagName(str) {
         if (str.includes('<')) {
-            const matchResult = str.match(/^.*\<([a-zA-Z-_.#@]+)[^>]*?/)
-            return matchResult && matchResult[1]
+            const matchResult = str.match(
+              /<(?![\!\/])([A-Za-z]{1}[^>\s=\'\"]*)[^>]*?/
+            );
+
+            return matchResult && matchResult[matchResult.length - 1]
         }
     },
     /**


### PR DESCRIPTION
This addresses pull request #11 .